### PR TITLE
Fix: Not Displaying/Tiling Un-Named Applications

### DIFF
--- a/AmethystWindows/DesktopWindowsManager/DesktopWindow.cs
+++ b/AmethystWindows/DesktopWindowsManager/DesktopWindow.cs
@@ -205,7 +205,7 @@ namespace AmethystWindows.DesktopWindowsManager
                     }
                     break;
             }
-            if (name == null)
+            if (name == "")
             {
                 name = fileName.Split(new string[] { "\\" }, StringSplitOptions.None).Last();
             }


### PR DESCRIPTION
References issues #75, #76

Some applications do not display in the Amethyst tabs (Managed Windows/Excluded Windows/Filters/Additions).
It looks like these apps are not listed because desktopWindow.AppName does not get assigned and remains "".

Making this string comparison change from null to "", allows apps that fail the initial naming options to obtain a name, display in the Amethyst list, and be controlled normally.

Let me know if this is how you would like the pull request to come through. Thank you.