### PR TITLE
RotateLayoutsCounterClockwise hotkey rotates layout twice (still)

### DIFF
--- a/AmethystWindows/MainWindow.xaml.cs
+++ b/AmethystWindows/MainWindow.xaml.cs
@@ -133,14 +133,6 @@ namespace AmethystWindows
                     DesktopWindow selected = App.DWM.FindWindow(selectedWindow);
                     App.DWM.MoveWindowNextScreen(selected);
                 }
-                if (wParam.ToInt32() == 0x21)
-                {
-                    HMONITOR currentMonitor = User32.MonitorFromWindow(User32.GetForegroundWindow(), User32.MonitorFlags.MONITOR_DEFAULTTONEAREST);
-                    VirtualDesktop currentDesktop = VirtualDesktop.Current;
-                    Pair<VirtualDesktop, HMONITOR> currentPair = new Pair<VirtualDesktop, HMONITOR>(currentDesktop, currentMonitor);
-                    ViewModelDesktopMonitor viewModelDesktopMonitor = mainWindowViewModel.DesktopMonitors[currentPair];
-                    viewModelDesktopMonitor.RotateLayoutCounterClockwise();
-                }
                 if (wParam.ToInt32() == 0x26)
                 {
                     HWND selectedWindow = User32.GetForegroundWindow();


### PR DESCRIPTION
The bug described in closed issue https://github.com/glsorre/amethystwindows/issues/45 still exists in the current master. Fix is the same as last time. Cheers.